### PR TITLE
Split bot into three modules

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -1,0 +1,73 @@
+from stonks import get_stocks
+
+def validate_message(msg):
+    msg = msg.split()
+    if len(msg) < 2:
+        return False
+
+    if msg[0] not in ['stocks', 'stockbot', 'stonks']:
+        return False
+
+    return True
+
+def list_price(command, msg):
+    msg_spl = msg.split()
+
+    if len(msg_spl) != 3:
+        return f"Error: 'stockbot {command} <symbol>"
+
+    stonks = msg_spl[0]
+    command_name = msg_spl[1]
+    symbol = msg_spl[2]
+
+    # TODO: Really this shouldn't be here... we should handle this way better..
+    # but I was feeling lazy and this gets the job done
+    try:
+        current_price = get_stocks(symbol)
+    except:
+        return f"Unable to find information for: '{symbol}'"
+
+    return f'current price for {symbol}: ${current_price}'
+
+###############################################################################
+#   All supported commands can be specified in this dict.  For each command,
+#   the command name is expected to point to a function that accepts two
+#   arguments: The name of the command and the message provided by the user.
+#
+#   Realistically based on the way it is implemented right now, the message is
+#   the only argument you really need, but accepting the command as an argument
+#   allows for more flexibility in the future (if the position of the command
+#   becomes variable).
+###############################################################################
+commands = {
+    "list_price": list_price,
+    "help": lambda cmd, msg: "Choose from:\n" + "\n".join(commands.keys())
+}
+
+def parse_message(msg):
+    """
+        It is expected that the message argument to this function has already
+        been validated.
+    """
+    command = msg.split()[1]
+
+    if command not in commands:
+        return f"Invalid command '{command}'"
+
+    return commands[command](command, msg)
+
+if __name__ == '__main__':
+    inp = ""
+    while inp != 'quit':
+        try:
+            inp=input(">>> ")
+        except KeyboardInterrupt:
+            break
+
+        if not validate_message(inp):
+            print("Invalid message")
+            continue
+
+        print("\n" + parse_message(inp) + "\n")
+
+    print("\nGoodbye!")

--- a/stonks.py
+++ b/stonks.py
@@ -1,0 +1,13 @@
+import os
+import requests
+
+def get_stocks(symbol: str) -> str:
+    finhub_api_key = os.environ["FINHUB_API_KEY"]
+
+    r = requests.get(f'https://finnhub.io/api/v1/quote?symbol={symbol}&token={finhub_api_key}')
+    body = r.json()
+    if "error" in body:
+        return body["error"]
+
+    current_price = body["c"]
+    return current_price


### PR DESCRIPTION
So I did a few things.  I didn't want to create my own discord bot to test, so I assumed that part would just work (message events and replying to messages).  What I did is I created a module just for parsing the messages.  I didn't really add any functionality, but I split up the code in such a way that adding new features down the line should be really easy.  I also added a main loop to the parser module that allows a user to test their new commands.

- Bot Module:
Handles discord things

- Parser Module:
Handles messages.  Parses them, generates response.
There is a main loop that takes input from the user.  This input is expected to be in the same format as a discord message.  This way you can test the behavior of your new function without having to deploy it to discord first.

- Stonks Module:
Gets stock prices / information
I created this because I didn't think that it made sense to be in the parser module... if you think there is a better place for it let me know.  Obviously we can't put it in the bot module because then that would create a circular dependency between parser and bot..